### PR TITLE
NM: Store password using the user keyring

### DIFF
--- a/internal/nm/nm.go
+++ b/internal/nm/nm.go
@@ -101,7 +101,7 @@ func Install(n network.NonTLS) error {
 		"ca-cert":            cert,
 		"anonymous-identity": n.AnonIdentity,
 		"password":           n.Credentials.Password,
-		"password-flags":     0,
+		"password-flags":     1,
 		"altsubject-matches": sids,
 	}
 	if n.InnerAuth.EAP() && n.MethodType == method.TTLS {


### PR DESCRIPTION
This prevents the password from being used by other users. I think it's good that this is off by default

See https://people.freedesktop.org/~lkundrak/nm-docs/nm-settings.html#secrets-flags

and

https://github.com/GEANT/CAT/issues/264