### PR TITLE
CLI: Add a flag for local import

### DIFF
--- a/cmd/geteduroam/main.go
+++ b/cmd/geteduroam/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"log"
 	"os"
@@ -271,7 +272,18 @@ func oauth(p *instance.Profile) {
 	}
 }
 
-func main() {
+func doLocal(filename string) {
+	    b, err := os.ReadFile(filename)
+	    if err != nil {
+		    log.Fatalf("Failed to read local file: %v", err)
+	    }
+	    err = file(b)
+	    if err != nil {
+		    log.Fatalf("Failed to configure the connection using the metadata: %v", err)
+	    }
+}
+
+func doDiscovery() {
 	c := discovery.NewCache()
 	i, err := c.Instances()
 	if err != nil {
@@ -291,6 +303,17 @@ func main() {
 		return
 	case instance.OAuthFlow:
 		oauth(p)
+	}
+}
+
+func main() {
+	local := flag.String("local", "", "The path to a local EAP metadata file")
+	flag.Parse()
+
+	if local != nil && *local != "" {
+		doLocal(*local)
+	} else {
+		doDiscovery()
 	}
 	fmt.Println("\nYour eduroam connection has been added to NetworkManager with the name eduroam (from Geteduroam)")
 }


### PR DESCRIPTION
An improvement would be to automagically use the right file once it's supplied in the same directory as the binary e.g. if the client sees there is a "metadata.eap-config" (or some other name) available it should ask the user if it wants to configure this file instead of fetching discovery.

For now it's a flag which is very handy for debugging.