### PR TITLE
Login: Fix invalid toast unref

### DIFF
--- a/cmd/geteduroam-gui/login.go
+++ b/cmd/geteduroam-gui/login.go
@@ -36,10 +36,10 @@ func NewLoginState(builder *gtk.Builder, stack *adw.ViewStack, cred network.Cred
 
 func (l *LoginState) ShowError(msg string) {
 	toast := adw.NewToast(msg)
-	defer toast.Unref()
 	toast.SetTimeout(5)
 	var overlay adw.ToastOverlay
 	l.builder.GetObject("loginToastOverlay").Cast(&overlay)
+	defer overlay.Unref()
 	overlay.AddToast(toast)
 }
 


### PR DESCRIPTION
We should only unref the overlay as the reference count for the toast is not increased. This *could* crash the app when you close the toast