### PR TITLE
Add "Get it on Flathub" button to README + Screenshot URL update

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This repository contains the source code for the geteduroam Linux client. Currently WIP.
 
+[![Get it on Flathub](https://flathub.org/api/badge?locale=en)](https://flathub.org/apps/app.eduroam.geteduroam)
+
 # Install through DEB/RPM
 To install the client using official packages, go to the [GitHub
 releases page](https://github.com/geteduroam/linux-app/releases) and

--- a/cmd/geteduroam-gui/flatpak/app.eduroam.geteduroam.metainfo.xml
+++ b/cmd/geteduroam-gui/flatpak/app.eduroam.geteduroam.metainfo.xml
@@ -34,11 +34,11 @@
   <launchable type="desktop-id">app.eduroam.geteduroam.desktop</launchable>
   <screenshots>
     <screenshot type="default">
-      <image>https://raw.githubusercontent.com/PucklaJ/linux-app/2aafcd8fb574e6631fd1af4041a942081bc66d85/cmd/geteduroam-gui/flatpak/start.png</image>
+      <image>https://raw.githubusercontent.com/geteduroam/linux-app/986c96313a766bf3baf7cc5f122e66ec49627206/cmd/geteduroam-gui/flatpak/start.png</image>
       <caption>A simple GUI to login to eduroam</caption>
     </screenshot>
     <screenshot type="default">
-      <image>https://raw.githubusercontent.com/PucklaJ/linux-app/2aafcd8fb574e6631fd1af4041a942081bc66d85/cmd/geteduroam-gui/flatpak/success.png</image>
+      <image>https://raw.githubusercontent.com/geteduroam/linux-app/986c96313a766bf3baf7cc5f122e66ec49627206/cmd/geteduroam-gui/flatpak/success.png</image>
       <caption>A NetworkManager profile will be created automatically</caption>
     </screenshot>
   </screenshots>


### PR DESCRIPTION
This PR adds the "Get it on Flathub" button to the README and updates the screenshot URLs to the upstream repository instead of pointing to my fork.